### PR TITLE
add_file_name_template

### DIFF
--- a/controller/ingest/file_ingest.py
+++ b/controller/ingest/file_ingest.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import re
+from string import Template
 
 from common.signal import Signal, Signals
 
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 def ingest(ingest_config):
     signals = Signals()
     ingest_file = ingest_config['file_name']
+    ingest_name_template = ingest_config['ingest_name_template'] if 'ingest_name_template' in ingest_config else None
     ingest_filter_metadata = ingest_config['filter_metadata'] if 'filter_metadata' in ingest_config else None
 
     signals.metadata["ingest_type"] = "file"
@@ -43,6 +45,8 @@ def ingest(ingest_config):
                 if not re.findall(ingest_filter_metadata, str(json_signal["metric"])):
                     continue
             signal_type = "metric"
+            if ingest_name_template:
+                json_signal["metric"]["__name__"] = Template(ingest_name_template).substitute(json_signal["metric"])
             signal_metadata = json_signal["metric"]
             signal_time_series = json_signal["values"]
         else:


### PR DESCRIPTION
Add the ability to set the names of metrics from a variable in file ingest using fields from the metadata. For example in the Instana  fetch folder:

when using ``` ingest_name_template: "$plugin-$instance-$__name__"``` we will be able to build the name from the plugin, instance and the __name__ fields

- name: ingest_file
  type: ingest
  subtype: file
  input_data: []
  output_data: [signals]
  config:
    filter_metadata: "latency"
    ingest_name_template: "$plugin-$instance-$__name__"
    file_name: ../contrib/fetch-offline-data/instana/promql_metrics.json


