### PR TITLE
Add k8s resources, README covering instructions and makefile target

### DIFF
--- a/contrib/end2end/poc/rule_based_poc/Makefile
+++ b/contrib/end2end/poc/rule_based_poc/Makefile
@@ -1,0 +1,15 @@
+# Set the default target
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Deploy k8s resources
+up-k8s: 
+	sed 's/APP_HOST/${APPHOST}/g' k8s/ingress.tmpl > k8s/k8s-ingress.yml
+	- kubectl create namespace ovm
+	kubectl apply -f 'k8s/k8s-*'
+
+down-k8s:
+	kubectl delete namespace ovm

--- a/contrib/end2end/poc/rule_based_poc/README.md
+++ b/contrib/end2end/poc/rule_based_poc/README.md
@@ -93,7 +93,7 @@ This showcases the transformation happening in an automated fashion.
 
 1. The `k8s` directory contains the specifications for deployments, services, PVCs and PVClaims for the POC. It also includes the ingress definitions. The ingress definitions require the `APP_HOST` variable to be set to the DNS address configured for applications running on your kubernetes cluster. The following make command will create an `ovm` namespace, sed the specified `APPHOST` variable into the ingress definitions and apply the resources to the cluster.
 ```
-APPHOST=your-desired-apphost make up-k8s-kubectl
+APPHOST=your-desired-apphost make up-k8s
 ``` 
 2. Add the rules and actions (in the form of transformation) corresponding to the rule
 ```

--- a/contrib/end2end/poc/rule_based_poc/README.md
+++ b/contrib/end2end/poc/rule_based_poc/README.md
@@ -11,12 +11,27 @@ Both the PoC scenarios which can also happen simulatenously, we also showcase ho
 
 ## Environment Setup
 
+### Docker
+
 The PoC requires docker installed on the machine to test the scenario. The following containers get installed when the PoC environment is bought up.\
 Central containers:
 - `thanos-receive`
 - `thanos-query`
 - `thanos-ruler`
 - `ruler-config`
+- `alertmanager`
+- `manager`\
+Edge containers:
+- `metricgen1,2`
+- `prometheus1,2`
+- `pmf_processsor1,2`
+
+### Kubernetes
+
+The PoC requires a kubernetes cluster to test the scenario. The following pods get deployed when the PoC environment is bought up.\
+Central pods:
+- `thanos` (comprising the thanos-receive and thanos-query containers)
+- `thanos-ruler` (comprising the thanos-ruler and ruler-config containers)
 - `alertmanager`
 - `manager`\
 Edge containers:
@@ -32,7 +47,7 @@ The rules are specified by the user in a yaml format. The manager parses them an
 
 Note that the actions (firing and resolved) are stored by the manager and applied to the corresponding edge processor when the alert is fired/resolved.
 
-## Running the PoC story
+## Running the PoC story - Docker
 
 1. Bring up the PoC environment
 ``` 
@@ -72,5 +87,44 @@ This showcases the transformation happening in an automated fashion.
 -   Note: The PoC can also be tested with using OTel Collector instead of prometheus. For this the only step that will change is - <em> 1. Bring up the PoC environment</em> to below
     ``` 
     docker-compose -f docker-compose-otel.yml up -d
+    ```
+
+## Running the PoC story - Kubernetes
+
+1. The `k8s` directory contains the specifications for deployments, services, PVCs and PVClaims for the POC. It also includes the ingress definitions. The ingress definitions require the `APP_HOST` variable to be set to the DNS address configured for applications running on your kubernetes cluster. The following make command will create an `ovm` namespace, sed the specified `APPHOST` variable into the ingress definitions and apply the resources to the cluster.
+```
+APPHOST=your-desired-apphost make up-k8s-kubectl
+``` 
+2. Add the rules and actions (in the form of transformation) corresponding to the rule
+```
+curl -X POST --data-binary @demo_2rules.yaml -H "Content-type: text/x-yaml" http://manager.YOUR_APP_HOST/api/v1/rules
+```
+3. Confirm the two rules are added correctly in the `thanos ruler` UI:
+`http://thanos-ruler.YOUR_APP_HOST/rules`
+4. Confirm the metrics are flowing correctly in the `thanos query` UI:
+`http://thanos-query.YOUR_APP_HOST`\
+Search for `cluster_hardware_metric_0` and `app_A_network_metric_0`. You should see 6 metrics (3 for each edge) for each of these. The edge can be identified by the `processor` label in the metric.
+5. Next, we instrument the issue scenario with metric value change. We apply the value change to metricgen for each edges (`metricgen1` and `metricgen2`)
+    - For issue at east edge: `curl -X POST --data-binary @change_appmetric.yml -H "Content-type: text/x-yaml" http://metricgen1.YOUR_APP_HOST`
+    - For issue at west edge: `curl -X POST --data-binary @change_hwmetric.yml -H "Content-type: text/x-yaml" http://metricgen2.YOUR_APP_HOST`
+6. You can visualize the change in the metrics value in the `thanos query` UI (in the graph mode)
+7. The alert should also be firing and can be seen in the `thanos ruler` UI (`http://thanos-ruler.YOUR_APP_HOST/alerts`)
+   P.S. Wait for 30sec-1min before checking this step. 
+8. The manager triggers adding of the corresponding transforms. To check the transforms added got to Manager API: `http://manager.YOUR_APP_HOST/apidocs/#/Processor%20Configuration/getProcessorConfig` and use `east` and `west` as processor id.\
+   P.S. This step is just for extra confirmation and is optional. 
+9. To visualize the transformation thanos query UI (in the graph mode).
+    - If you search `app_A_network_metric_0{processor="east"}` you will see the metric with label `IP:192.168.1.3` has changing value but the other metrics with label `IP:192.168.1.1` and `IP:192.168.1.2` with no change (straight line; showcasing no value change or should stop completely).\ This is because we have filtered and allowed `app_A_network_metric_0` only for app with `IP:192.168.1.3`.
+    - If you search `cluster_hardware_metric_0{processor="west"}` you will see the metric with label `node:'0'` having a nice sinusoidal wave. This is because its value is changing every 5 sec. The other metrics with label `node:'1'` and `node:'2'` will be blocky showing their frequency is still 30 sec. 
+This showcases the transformation happening in an automated fashion.
+10. We will just revert issue in edge cloud east and showcase that we work on specific cloud as well.
+    ```
+    curl -X POST --data-binary @change_appmetricRESET.yml -H "Content-type: text/x-yaml" http://metricgen1.YOUR_APP_HOST
+    ```
+    In sometime, you should see the alert rule 1 resolved (in thanos ruler UI (`http://thanos-ruler.YOUR_APP_HOST/alerts`)) and should see the metric `app_A_network_metric_0{processor="east"}` again coming in for labels `IP:192.168.1.1` and `IP:192.168.1.2` as well demontrating the removal of `filter` transform from edge cloud 1. 
+
+11. P.S. One can revert the transformation applied to west edge as well using the below command.
+    ```
+    curl -X POST --data-binary @change_hwmetricRESET.yml -H "Content-type: text/x-yaml" http://metricgen2.YOUR_APP_HOST
+
     ```
 

--- a/contrib/end2end/poc/rule_based_poc/k8s/ingress.tmpl
+++ b/contrib/end2end/poc/rule_based_poc/k8s/ingress.tmpl
@@ -1,0 +1,84 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thanos-ruler
+spec:
+  rules:
+  - host: thanos-ruler.APP_HOST
+    http:
+      paths:
+      - backend:
+          service:
+            name: thanosruler
+            port:
+              number: 10903
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: thanos-query
+spec:
+  rules:
+  - host: thanos-query.APP_HOST
+    http:
+      paths:
+      - backend:
+          service:
+            name: thanosquery
+            port:
+              number: 19192
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: manager
+spec:
+  rules:
+  - host: manager.APP_HOST
+    http:
+      paths:
+      - backend:
+          service:
+            name: manager
+            port:
+              number: 5010
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metricgen1
+spec:
+  rules:
+  - host: metricgen1.APP_HOST
+    http:
+      paths:
+      - backend:
+          service:
+            name: metricgen1
+            port:
+              number: 5002
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metricgen2
+spec:
+  rules:
+  - host: metricgen2.APP_HOST
+    http:
+      paths:
+      - backend:
+          service:
+            name: metricgen2
+            port:
+              number: 5003
+        path: /
+        pathType: Prefix

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-alertmanager.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-alertmanager.yml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: alertmanager
+  name: alertmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: alertmanager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: alertmanager
+    spec:
+      containers:
+        - image: quay.io/prometheus/alertmanager:v0.25.0
+          livenessProbe:
+            exec:
+              command:
+                - wget -q -O- localhost:9093/-/ready
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: alertmanager
+          ports:
+            - containerPort: 9093
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config/config.yaml
+              subPath: config.yaml
+      restartPolicy: Always
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager-config
+            items:
+              - key: alertmanager.yaml
+                path: alertmanager.yaml
+            defaultMode: 420
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: alertmanager
+  name: alertmanager
+spec:
+  ports:
+    - name: "9093"
+      port: 9093
+      targetPort: 9093
+  selector:
+    ovm.service: alertmanager
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: alertmanager-config
+data:
+  alertmanager.yaml: |-
+    global:
+      http_config: 
+        proxy_url: 'http://manager:5010'
+    route:
+      group_by: ['alertname']
+      group_wait: 1s
+      group_interval: 15s
+      repeat_interval: 1h
+      receiver: 'web.hook'
+    receivers:
+      - name: 'web.hook'
+        webhook_configs:
+          - url: 'http://manager:5010/alerthandler'
+    inhibit_rules:
+      - source_match:
+          severity: 'critical'
+        target_match:
+          severity: 'warning'
+        equal: ['alertname', 'dev', 'instance']

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-grafana.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-grafana.yml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: grafana
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: grafana
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: grafana
+    spec:
+      containers:
+        - image: grafana/grafana-enterprise
+          name: grafana
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning
+              name: grafana-claim0
+      restartPolicy: Always
+      volumes:
+        - name: grafana-claim0
+          persistentVolumeClaim:
+            claimName: grafana-claim0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: grafana
+  name: grafana
+spec:
+  ports:
+    - name: "3000"
+      port: 3000
+      targetPort: 3000
+  selector:
+    ovm.service: grafana
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: grafana-claim0
+  name: grafana-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-manager.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-manager.yml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: manager
+  name: manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: manager
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: manager
+    spec:
+      containers:
+        - env:
+            - name: CONFIG_FILE
+              value: /etc/config/config.yaml
+          image: quay.io/observ-vol-mgt/manager:latest
+          name: manager
+          ports:
+            - containerPort: 5010
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config/config.yaml
+              subPath: config.yaml
+            - mountPath: /manager/app
+              name: manager-volume
+      restartPolicy: Always
+      volumes:
+        - name: manager-volume
+          persistentVolumeClaim:
+            claimName: manager-volume
+        - name: config
+          configMap:
+            name: manager-config
+            items:
+              - key: config.yaml
+                path: config.yaml
+            defaultMode: 420
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: manager
+  name: manager
+spec:
+  ports:
+    - name: 5010-tcp
+      port: 5010
+      targetPort: 5010
+  selector:
+    ovm.service: manager
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: manager-volume
+  name: manager-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: manager-config
+data:
+  config.yaml: |-
+    HOST: '0.0.0.0'
+    PORT: 5010
+    APP_URL_PREFIX: "/api/v1"
+    LOG_FILE: "./app/logs/manager.log"
+    PROCESSORS_FOLDER: "./app/processors"
+    RULES_FOLDER: "./app/rules"
+    PROCESSOR_east_URL: "http://pmfprocessor1.ovm.svc.cluster.local:8100/morphchain"
+    PROCESSOR_west_URL: "http://pmfprocessor2.ovm.svc.cluster.local:8101/morphchain"
+    ALERTMANAGER_URL: "http://thanos-ruler.ovm.svc.cluster.local:8090"
+    CONTROLLER_URL: "http://controller:5000/api/v1/rerun"

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-metricgen1.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-metricgen1.yml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    ovm.service: metricgen1
+  name: metricgen1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: metricgen1
+  template:
+    metadata:
+      labels:
+        ovm.service: metricgen1
+    spec:
+      containers:
+        - args:
+            - python3
+            - demo-metrics-gutentag.py
+            - --conf=conf.yaml
+            - -p=8000
+            - -cp=5002
+            - --nmetrics=100
+            - --nlabels=10
+            - --duplicate=false
+          image: quay.io/observ-vol-mgt/metricgen
+          name: metricgen1
+          ports:
+            - containerPort: 5002
+              protocol: TCP
+            - containerPort: 8000
+              protocol: TCP
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: metricgen1
+  name: metricgen1
+spec:
+  ports:
+    - name: "5002"
+      port: 5002
+      targetPort: 5002
+    - name: "8000"
+      port: 8000
+      targetPort: 8000
+  selector:
+    ovm.service: metricgen1

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-metricgen2.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-metricgen2.yml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    ovm.service: metricgen2
+  name: metricgen2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: metricgen2
+  template:
+    metadata:
+      labels:
+        ovm.service: metricgen2
+    spec:
+      containers:
+        - args:
+            - python3
+            - demo-metrics-gutentag.py
+            - --conf=conf.yaml
+            - --port=8001
+            - --clientport=5003
+            - --nmetrics=100
+            - --nlabels=10
+            - --duplicate=false
+          image: quay.io/observ-vol-mgt/metricgen
+          name: metricgen2
+          ports:
+            - containerPort: 5003
+              protocol: TCP
+            - containerPort: 8001
+              protocol: TCP
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: metricgen2
+  name: metricgen2
+spec:
+  ports:
+    - name: "5003"
+      port: 5003
+      targetPort: 5003
+    - name: "8001"
+      port: 8001
+      targetPort: 8001
+  selector:
+    ovm.service: metricgen2

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-pmf-processor1.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-pmf-processor1.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: pmf-processor1
+  name: pmf-processor1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: pmf-processor1
+  template:
+    metadata:
+      annotations:
+      labels:
+        ovm.service: pmf-processor1
+    spec:
+      containers:
+        - args:
+            - ./processor
+            - --listen=:8081
+            - --morpher=:8100
+            - --target=http://thanosreceive.ovm.svc.cluster.local:19291/api/v1/recieve
+          image: quay.io/observ-vol-mgt/pmf_processor:v0.1
+          name: pmf-processor1
+          ports:
+            - containerPort: 8100
+              protocol: TCP
+            - containerPort: 8081
+              protocol: TCP
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: pmf-processor1
+  name: pmfprocessor1
+spec:
+  ports:
+    - name: "8100"
+      port: 8100
+      targetPort: 8100
+    - name: "8081"
+      port: 8081
+      targetPort: 8081
+  selector:
+    ovm.service: pmf-processor1

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-pmf-processor2.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-pmf-processor2.yml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: pmf-processor2
+  name: pmf-processor2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: pmf-processor2
+  template:
+    metadata:
+      labels:
+        ovm.service: pmf-processor2
+    spec:
+      containers:
+        - args:
+            - ./processor
+            - --listen=0.0.0.0:8082
+            - --morpher=0.0.0.0:8101
+            - --target=http://thanosreceive.ovm.svc.cluster.local:19291/api/v1/recieve
+          image: quay.io/observ-vol-mgt/pmf_processor:v0.1
+          name: pmf-processor2
+          ports:
+            - containerPort: 8101
+              protocol: TCP
+            - containerPort: 8082
+              protocol: TCP
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: pmf-processor2
+  name: pmfprocessor2
+spec:
+  ports:
+    - name: "8101"
+      port: 8101
+      targetPort: 8101
+    - name: "8082"
+      port: 8082
+      targetPort: 8082
+  selector:
+    ovm.service: pmf-processor2

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-prometheus1.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-prometheus1.yml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: prometheus1
+  name: prometheus1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: prometheus1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: prometheus1
+    spec:
+      containers:
+        - args:
+            - --config.file=/etc/config/prometheus1-config.yaml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --storage.tsdb.retention.time=2h
+            - --web.enable-lifecycle
+            - --web.enable-admin-api
+            - --web.listen-address=:9001
+            - --storage.tsdb.min-block-duration=5m
+            - --storage.tsdb.max-block-duration=5m
+          image: quay.io/prometheus/prometheus:v2.55.0
+          name: prometheus1
+          ports:
+            - containerPort: 9001
+              protocol: TCP
+          volumeMounts:
+            - name: prometheus1-config 
+              mountPath: /etc/config/prometheus1-config.yaml
+              subPath: prometheus1-config.yaml
+            - mountPath: /data
+              name: prometheus1-data
+      restartPolicy: Always
+      volumes:
+        - name: prometheus1-config
+          configMap:
+            name: prometheus1-config
+            items:
+              - key: prometheus1-config.yaml
+                path: prometheus1-config.yaml
+            defaultMode: 420
+        - name: prometheus1-data
+          persistentVolumeClaim:
+            claimName: prometheus1-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: prometheus1
+  name: prometheus1
+spec:
+  ports:
+    - name: "9001"
+      port: 9001
+      targetPort: 9001
+  selector:
+    ovm.service: prometheus1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: prometheus1-data
+  name: prometheus1-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus1-config
+data:
+  prometheus1-config.yaml: |-
+    # my global config
+    global:
+      scrape_interval: 5s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+      external_labels:
+        processor: "east"
+      # scrape_timeout is set to the global default (10s).
+
+    # Alertmanager configuration
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets:
+              # - alertmanager:9093
+
+    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+    rule_files:
+      # - "first_rules.yml"
+      # - "second_rules.yml"
+
+    # A scrape configuration containing exactly one endpoint to scrape:
+    # Here it's Prometheus itself.
+    scrape_configs:
+      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+      - job_name: "prometheus"
+
+        # metrics_path defaults to '/metrics'
+        # scheme defaults to 'http'.
+
+        static_configs:
+          - targets: ["metricgen1:8000"]
+          #- targets: ["localhost:9090"]
+    remote_write:
+      - url: "http://pmfprocessor1.ovm.svc.cluster.local:8081/api/v1/receive"
+        queue_config:
+          max_samples_per_send: 200

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-prometheus2.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-prometheus2.yml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: prometheus2
+  name: prometheus2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: prometheus2
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: prometheus2
+    spec:
+      containers:
+        - args:
+            - --config.file=/etc/config/prometheus2-config.yaml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --storage.tsdb.retention.time=2h
+            - --web.enable-lifecycle
+            - --web.enable-admin-api
+            - --web.listen-address=:9002
+            - --storage.tsdb.min-block-duration=5m
+            - --storage.tsdb.max-block-duration=5m
+          image: quay.io/prometheus/prometheus:v2.55.0
+          name: prometheus2
+          ports:
+            - containerPort: 9002
+              protocol: TCP
+          volumeMounts:
+            - name: prometheus2-config
+              mountPath: /etc/config/prometheus2-config.yaml
+              subPath: prometheus2-config.yaml
+            - mountPath: /data
+              name: prometheus2-data
+      restartPolicy: Always
+      volumes:
+        - name: prometheus2-config
+          configMap:
+            name: prometheus2-config
+            items:
+              - key: prometheus2-config.yaml
+                path: prometheus2-config.yaml
+            defaultMode: 420
+        - name: prometheus2-data
+          persistentVolumeClaim:
+            claimName: prometheus2-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: prometheus2
+  name: prometheus2
+spec:
+  ports:
+    - name: "9002"
+      port: 9002
+      targetPort: 9002
+  selector:
+    ovm.service: prometheus2
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: prometheus2-data
+  name: prometheus2-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus2-config
+data:
+  prometheus2-config.yaml: |-
+    # my global config
+    global:
+      scrape_interval: 5s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+      evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+      external_labels:
+        processor: "west"
+      # scrape_timeout is set to the global default (10s).
+
+    # Alertmanager configuration
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets:
+              # - alertmanager:9093
+
+    # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+    rule_files:
+      # - "first_rules.yml"
+      # - "second_rules.yml"
+
+    # A scrape configuration containing exactly one endpoint to scrape:
+    # Here it's Prometheus itself.
+    scrape_configs:
+      # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+      - job_name: "prometheus"
+
+        # metrics_path defaults to '/metrics'
+        # scheme defaults to 'http'.
+
+        static_configs:
+          - targets: ["metricgen2:8001"]
+          #- targets: ["localhost:9090"]
+    remote_write:
+      - url: "http://pmf_processor2:8082/api/v1/receive"
+        queue_config:
+          max_samples_per_send: 200

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-ruler-config.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-ruler-config.yml
@@ -1,0 +1,276 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: thanosruler
+  name: thanos-ruler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: thanosruler
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        ovm.service: thanosruler
+    spec:
+      containers:
+        - name: thanos-ruler
+          args:
+            - rule
+            - --log.level=debug
+            - --log.format=logfmt
+            - --grpc-address=:30901
+            - --http-address=:10903
+            - --query=thanos_query:19192
+            - --rule-file=/shared/rules.yml
+            - --alertmanagers.url=http://alertmanager.ovm.svc.cluster.local:9093
+            - --data-dir=/shared/data
+          image: thanosio/thanos:v0.29.0
+          livenessProbe:
+            exec:
+              command:
+                - wget -q -O- localhost:10903/-/ready
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 10903
+              protocol: TCP
+            - containerPort: 30901
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /shared
+              name: shared-data
+        - name: ruler-config
+          env:
+            - name: HOST
+              value: 0.0.0.0
+            - name: LOG_FILE
+              value: ruleTranslator.log
+            - name: PORT
+              value: "8090"
+            - name: RULES_FOLDER
+              value: /shared
+            - name: THANOS_RULE_URL
+              value: http://thanosruler.ovm.svc.cluster.local:10903
+          image: quay.io/observ-vol-mgt/ruler_config:latest
+          name: ruler-config
+          ports:
+            - containerPort: 8090
+              protocol: TCP
+          volumeMounts:
+            - name: shared-data
+              mountPath: /shared
+            - name: thanos-ruler-endpoint
+              mountPath: /shared/thanos-ruler-endpoint.py
+              subPath: thanos-ruler-endpoint.py
+            - name: config
+              mountPath: /shared/config.py
+              subPath: config.py
+      restartPolicy: Always
+      volumes:
+        - name: shared-data
+          persistentVolumeClaim:
+            claimName: shared-data
+        - name: thanos-ruler-endpoint
+          configMap:
+            name: thanos-ruler-endpoint
+            items:
+              - key: thanos-ruler-endpoint.py
+                path: thanos-ruler-endpoint.py
+            defaultMode: 420
+        - name: config
+          configMap:
+            name: config
+            items:
+              - key: config.py
+                path: config.py
+            defaultMode: 420
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: thanosruler
+  name: thanosruler
+spec:
+  ports:
+    - name: "8090"
+      port: 8090
+      targetPort: 8090
+    - name: "10903"
+      port: 10903
+      targetPort: 10903
+    - name: "30901"
+      port: 30901
+      targetPort: 30901
+  selector:
+    ovm.service: thanosruler
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: shared-data
+  name: shared-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: thanos-ruler-endpoint
+data:
+  thanos-ruler-endpoint.py: |-
+    from flask import Flask, jsonify, request, abort
+    from flask_swagger_ui import get_swaggerui_blueprint
+    from config import *
+    import requests
+    import logging
+    import yaml
+    import os
+
+    app = Flask(__name__)
+    SWAGGER_URL="/swagger"
+    API_URL="/static/swagger.json"
+    HOST=os.environ.get('HOST')
+    PORT=os.environ.get('PORT')
+    RULES_FOLDER=os.environ.get('RULES_FOLDER')
+    THANOS_RULE_URL=os.environ.get('THANOS_RULE_URL')
+    LOG_FILE=os.environ.get('LOG_FILE')
+
+    swagger_ui_blueprint = get_swaggerui_blueprint(
+        SWAGGER_URL,
+        API_URL,
+        config={
+            'app_name': 'Thanos Ruler API'
+        }
+    )
+    app.register_blueprint(swagger_ui_blueprint, url_prefix=SWAGGER_URL)
+
+    log_dir = os.path.dirname(f'{LOG_FILE}')
+    logging.basicConfig(filename=f'{LOG_FILE}', filemode='w', level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    @app.route('/<rule_id>', methods=['POST'])
+    def create_rule(rule_id):
+        logger.debug(f"ADD alert rule {rule_id}")
+        try:
+            rule_data = request.get_data()
+            try:
+                r_data = yaml.safe_load(rule_data)
+            except Exception as e:
+                logger.error("Invalid yaml data")
+                return {"message":"Invalid YAML data"}, 400
+            description = r_data.get('description')
+            if 'description' not in r_data.keys():
+                description = r_data.get('expr')
+            #TODO: check if rule_id already exists
+            
+            new_yaml_data_dict = {
+                'alert': f'{rule_id}',
+                'annotations': {'description': description,
+                    'summary': 'Usage {{ $labels.label_0 }} of tenant {{ $labels.tenant_id }} is above 100.',
+                },
+                'expr': r_data.get('expr'),
+                'for': r_data.get('for'),
+                'labels': {'severity': 'critical'},
+            }
+            file_path = os.path.join(f"{RULES_FOLDER}", f"rules.yml")
+            with open(file_path,'r') as yamlfile:
+                exists = False
+                cur_yaml = yaml.safe_load(yamlfile)
+                for index in range(len(cur_yaml["groups"][0]["rules"])):
+                    if cur_yaml["groups"][0]["rules"][index]["alert"] == f'{rule_id}':
+                        cur_yaml["groups"][0]["rules"][index] = new_yaml_data_dict
+                        exists = True
+                        break
+                if exists != True:    
+                    if not cur_yaml["groups"][0]["rules"]:
+                        cur_yaml["groups"][0]["rules"] = []
+                    cur_yaml["groups"][0]["rules"].append(new_yaml_data_dict)
+            if cur_yaml:
+                with open(file_path,'w') as yamlfile:
+                    yaml.safe_dump(cur_yaml, yamlfile, default_flow_style=False, sort_keys=False) 
+            url = THANOS_RULE_URL + "/-/reload"
+            r = requests.post(url)
+            logger.info(f"POST request successful for rules")
+            return {"message":"success"}, 200
+
+        except Exception as e:
+            logger.error(f"Error occurred while creating rule: {str(e)}")
+            abort(500, "An error occurred while creating the rule")
+
+    @app.route('/<rule_id>', methods=['DELETE'])
+    def delete_rule(rule_id):
+        logger.debug(f"DELETE alert rule {rule_id}")
+        try:
+            file_path = os.path.join(f"{RULES_FOLDER}", f"rules.yml")
+            with open(file_path,'r') as yamlfile:
+                    cur_yaml = yaml.safe_load(yamlfile)
+            for alert in cur_yaml["groups"][0]["rules"]:
+                    if alert.get("alert") == f'{rule_id}':
+                        cur_yaml["groups"][0]["rules"].remove(alert)
+                        with open(file_path,'w') as yamlfile:
+                            yaml.safe_dump(cur_yaml, yamlfile, default_flow_style=False, sort_keys=False)
+                        url = THANOS_RULE_URL + "/-/reload"
+                        r = requests.post(url)
+                        logger.info(f"DELETE request successful for rules")
+                        return {"message":"success"}, 200  
+            return {"message":"success"}, 200
+        except Exception as e:
+            logger.error(f"Error occurred while deleting rule: {str(e)}")
+            abort(500, "An error occurred while deleting the rule")
+
+    @app.route('/<rule_id>', methods=['GET'])
+    def get_rule(rule_id):
+        logger.debug(f"GET alert rule {rule_id}")
+        try:
+            file_path = os.path.join(f"{RULES_FOLDER}", f"rules.yml")
+            with open(file_path,'r') as yamlfile:
+                    cur_yaml = yaml.safe_load(yamlfile)
+            for alert in cur_yaml["groups"][0]["rules"]:
+                    if alert.get("alert") == f'{rule_id}':
+                        logger.info(f"GET request successful for the rule {rule_id}")
+                        return jsonify(alert), 200
+            return {"message":"rule not found"}, 200
+        except Exception as e:
+            logger.error(f"Error occurred while getting rule: {str(e)}")
+            abort(500, "An error occurred while getting the rule")
+
+    @app.route('/rules', methods=['GET'])
+    def get_all_rules():
+        try:
+            rule_list = []
+            file_path = os.path.join(f"{RULES_FOLDER}", f"rules.yml")
+            with open(file_path,'r') as yamlfile:
+                    cur_yaml = yaml.safe_load(yamlfile) # Note the safe_load
+            for alert in cur_yaml["groups"][0]["rules"]:
+                rule_list.append(alert)
+            logger.debug(f"GET all rules successful")
+            return jsonify(rule_list), 200
+        except Exception as e:
+            logger.error(f"Error occurred while fetching rules: {str(e)}")
+            abort(500, "An error occurred while fetching the rules")
+    if __name__ == '__main__':
+        app.run(host=f"{HOST}", port=f"{PORT}", debug=True)
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: config
+data:
+  config.py: |-
+    HOST = "0.0.0.0"
+    PORT = 8090
+
+    RULES_FOLDER = "/Users/priyanka/Downloads/thanos-0.29.0.darwin-amd64"
+    THANOS_RULE_URL = 'http://0.0.0.0:10903'
+    LOG_FILE = "ruleTranslator.log"

--- a/contrib/end2end/poc/rule_based_poc/k8s/k8s-thanos.yml
+++ b/contrib/end2end/poc/rule_based_poc/k8s/k8s-thanos.yml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ovm.service: thanos
+  name: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ovm.service: thanos
+  template:
+    metadata:
+      labels:
+        ovm.service: thanos
+    spec:
+      containers:
+        - name: thanos-query
+          args:
+            - query
+            - --log.level=debug
+            - --log.format=logfmt
+            - --grpc-address=:20901
+            - --http-address=:19192
+            - --store=thanos_receive:10901
+            - --store.sd-interval=5m
+            - --query.replica-label=monitor
+          image: thanosio/thanos:v0.29.0
+          livenessProbe:
+            exec:
+              command:
+                - wget -q -O- localhost:19192/-/ready
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 19192
+              protocol: TCP
+            - containerPort: 20901
+              protocol: TCP
+        - name: thanos-receive
+          args:
+            - receive
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --remote-write.address=0.0.0.0:19291
+            - --receive.replication-factor=1
+            - --label=receive="true"
+            - --tsdb.path=/data/receive
+            - --tsdb.retention=15d
+            - --receive.local-endpoint=thanos-receive:10901
+          image: thanosio/thanos:v0.29.0
+          livenessProbe:
+            exec:
+              command:
+                - wget -q -O- localhost:10902/-/ready
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 19291
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: thanos-receive-claim0
+      restartPolicy: Always
+      volumes:
+        - name: thanos-receive-claim0
+          persistentVolumeClaim:
+            claimName: thanos-receive-claim0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: thanos-query
+  name: thanosquery
+spec:
+  ports:
+    - name: "19192"
+      port: 19192
+      targetPort: 19192
+    - name: "20901"
+      port: 20901
+      targetPort: 20901
+  selector:
+    ovm.service: thanos
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ovm.service: thanos-receive
+  name: thanosreceive
+spec:
+  ports:
+    - name: "19291"
+      port: 19291
+      targetPort: 19291
+  selector:
+    ovm.service: thanos
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    ovm.service: thanos-receive-claim0
+  name: thanos-receive-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
Adds k8s resources for the rule based PoC. I'll use these as a basis to update the other PoCs and the end2end deployment.

Instructions for deploying the resources are included in the README using the Makefile I added to the `rule_based_poc` directory.

I tested this on a full openshift cluster but only used k8s resources ( ingress rather than route for example ) so it should all work fine on a plain kubernetes cluster.